### PR TITLE
Drop .babelrc from node_modules.

### DIFF
--- a/.npmignore
+++ b/.npmignore
@@ -1,2 +1,3 @@
+.babelrc
 src
 coverage


### PR DESCRIPTION
Don't need babel settings in node_modules.
If we parse your module for polyfills babel can't find "external-helpers".